### PR TITLE
node.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
-/.idea
-/*.iml
+target
+.idea
+*.iml

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.webjars</groupId>
+        <artifactId>less-parent</artifactId>
+        <version>1.6.0-1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <artifactId>less-node</artifactId>
+    <name>LESS Node</name>
+    <description>WebJar for LESS Node modules</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <id>move</id>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <echo message="moving resources" />
+                                <move todir="${destDir}/lib">
+                                    <fileset dir="${extractDir}/lib" />
+                                </move>
+                                <move file="${extractDir}/package.json" todir="${destDir}" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
         <version>7</version>
     </parent>
 
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <groupId>org.webjars</groupId>
-    <artifactId>less</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
-    <name>LESS</name>
-    <description>WebJar for LESS</description>
+    <artifactId>less-parent</artifactId>
+    <version>1.6.0-1-SNAPSHOT</version>
+    <name>LESS Parent</name>
+    <description>WebJar for LESS Parent</description>
     <url>http://webjars.org</url>
 
     <licenses>
@@ -37,6 +37,14 @@
             <name>James Ward</name>
             <email>james@jamesward.org</email>
         </developer>
+        <developer>
+            <id>jroper</id>
+            <name>James Roper</name>
+        </developer>
+        <developer>
+            <id>huntchr</id>
+            <name>Christopher Hunt</name>
+        </developer>
     </developers>
     
     <properties>
@@ -46,57 +54,58 @@
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
         <extractDir>${project.build.directory}/less.js-${upstreamVersion}</extractDir>
     </properties>
-    
+
+    <modules>
+        <module>node</module>
+        <module>web</module>
+    </modules>
+
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>1.0-beta-4</version>
-                <executions>
-                    <execution>
-                        <id>download-js</id>
-                        <phase>process-resources</phase>
-                        <goals><goal>download-single</goal></goals>
-                        <configuration>
-                            <url>${sourceUrl}</url>
-                            <fromFile>v${upstreamVersion}.zip</fromFile>
-                            <toFile>${project.build.directory}/less.zip</toFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>wagon-maven-plugin</artifactId>
+                    <version>1.0-beta-4</version>
+                    <executions>
+                        <execution>
+                            <id>download-js</id>
+                            <phase>process-resources</phase>
+                            <goals><goal>download-single</goal></goals>
+                            <configuration>
+                                <url>${sourceUrl}</url>
+                                <fromFile>v${upstreamVersion}.zip</fromFile>
+                                <toFile>${project.build.directory}/less.zip</toFile>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <phase>process-resources</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <target>
-                                <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/less.zip" dest="${project.build.directory}" />
-                                <echo message="moving resources" />
-                                <move todir="${destDir}/node_modules">
-                                    <fileset dir="${extractDir}/lib" />
-                                </move>
-                                <move file="${extractDir}/package.json" todir="${destDir}/node_modules" />
-                                <move file="${extractDir}/dist/less-${upstreamVersion}.js" tofile="${destDir}/less.js" />
-                                <move file="${extractDir}/dist/less-${upstreamVersion}.min.js" tofile="${destDir}/less.min.js" />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.7</version>
+                    <executions>
+                        <execution>
+                            <phase>process-resources</phase>
+                            <id>unzip</id>
+                            <goals><goal>run</goal></goals>
+                            <configuration>
+                                <target>
+                                    <echo message="unzip archive" />
+                                    <unzip src="${project.build.directory}/less.zip" dest="${project.build.directory}" />
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-            </plugin>
-        </plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.3.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.webjars</groupId>
+        <artifactId>less-parent</artifactId>
+        <version>1.6.0-1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <artifactId>less</artifactId>
+    <name>LESS</name>
+    <description>WebJar for LESS</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <id>move</id>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <echo message="moving resources" />
+                                <move file="${extractDir}/dist/less-${upstreamVersion}.js" tofile="${destDir}/less.js" />
+                                <move file="${extractDir}/dist/less-${upstreamVersion}.min.js" tofile="${destDir}/less.min.js" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
node_modules is no longer required - also a new -node jar is to be used for node modules. The node jar is formatted in the same manner as it would appear to npm - only with the artefacts actually required instead of the whole project.
