### PR TITLE
Update to less 2.5.0

### DIFF
--- a/node/pom.xml
+++ b/node/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.webjars</groupId>
         <artifactId>less-parent</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,6 +35,7 @@
                                     <fileset dir="${extractDir}/lib" />
                                 </move>
                                 <move file="${extractDir}/package.json" todir="${destDir}" />
+                                <move file="${extractDir}/index.js" todir="${destDir}" />
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>less-parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <name>LESS Parent</name>
     <description>WebJar for LESS Parent</description>
     <url>http://webjars.org</url>
@@ -49,7 +49,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>2.3.1</upstreamVersion>
+        <upstreamVersion>2.5.0</upstreamVersion>
         <sourceUrl>https://github.com/less/less.js/archive</sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
         <extractDir>${project.build.directory}/less.js-${upstreamVersion}</extractDir>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.webjars</groupId>
         <artifactId>less-parent</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Also fixed bug in node package, package.json pointed to /index.js, which wasn't being included.